### PR TITLE
dataProvider processing, launch name refactor and launch finish

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,16 @@
       <version>2.10.3</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.8</version>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+    <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
       <version>2.0.1.Final</version>

--- a/src/main/java/com/deltareporter/client/BasicClient.java
+++ b/src/main/java/com/deltareporter/client/BasicClient.java
@@ -19,7 +19,9 @@ public interface BasicClient {
 
   HttpClient.Response<TestCaseType> finishTest(TestCaseType paramTestType);
 
-  HttpClient.Response<TestRunType> finishTestRun(TestRunType paramTestRunTyp);
+  HttpClient.Response<TestRunType> finishTestRun(TestRunType paramTestRunType);
+
+  HttpClient.Response<LaunchType> finishLaunch(LaunchType paramLaunchType);
 
   HttpClient.Response<TestCaseType> createTestCase(TestCaseType paramTestCaseType);
 

--- a/src/main/java/com/deltareporter/client/ExtendedClient.java
+++ b/src/main/java/com/deltareporter/client/ExtendedClient.java
@@ -6,7 +6,7 @@ import com.deltareporter.models.TestSuiteHistoryType;
 public interface ExtendedClient {
 
   TestCaseType registerTestCase(
-      String paramString1, String paramString2, Integer paramInteger1, Integer paramInteger2, Integer paramInteger3);
+      String paramString1, String paramString2, String paramString3, Integer paramInteger1, Integer paramInteger2, Integer paramInteger3);
 
   Integer registerLaunch(String paramString1, String paramString2);
 
@@ -18,4 +18,6 @@ public interface ExtendedClient {
   void finishTestSuiteHistory(Integer paramInteger1, String paramString2, String paramString3);
 
   void finishTestRun(Integer paramInteger1, String paramString2, String paramString3);
+
+  void finishLaunch(Integer paramInteger1);
 }

--- a/src/main/java/com/deltareporter/client/Path.java
+++ b/src/main/java/com/deltareporter/client/Path.java
@@ -6,6 +6,7 @@ public enum Path {
   TEST_SUITE_HISTORY_PATH("/api/v1/test_suite_history"),
   TEST_CASE_HISTORY_PATH("/api/v1/test_history"),
   LAUNCH_PATH("/api/v1/launch"),
+  LAUNCH_FINISH("/api/v1/finish_launch"),
   TEST_RUNS_PATH("/api/v1/test_run");
 
   private final String relativePath;

--- a/src/main/java/com/deltareporter/client/impl/BasicClientImpl.java
+++ b/src/main/java/com/deltareporter/client/impl/BasicClientImpl.java
@@ -66,8 +66,14 @@ public class BasicClientImpl implements BasicClient {
 
   public synchronized HttpClient.Response<TestRunType> finishTestRun(TestRunType testRun) {
     return HttpClient.uri(Path.TEST_RUNS_PATH, this.serviceURL, new Object[0])
-        .onFailure("Unable to create test run")
+        .onFailure("Unable to finish test run")
         .put(TestRunType.class, testRun);
+  }
+
+  public synchronized HttpClient.Response<LaunchType> finishLaunch(LaunchType launch) {
+    return HttpClient.uri(Path.LAUNCH_FINISH, this.serviceURL, new Object[0])
+        .onFailure("Unable to finish launch")
+        .put(LaunchType.class, launch);
   }
 
   public synchronized HttpClient.Response<TestCaseType> createTestCase(TestCaseType testCase) {

--- a/src/main/java/com/deltareporter/client/impl/DeltaClientImpl.java
+++ b/src/main/java/com/deltareporter/client/impl/DeltaClientImpl.java
@@ -41,6 +41,10 @@ public class DeltaClientImpl implements DeltaClient {
     return this.basicClient.finishTestRun(testRun);
   }
 
+  public HttpClient.Response<LaunchType> finishLaunch(LaunchType testLaunch) {
+    return this.basicClient.finishLaunch(testLaunch);
+  }
+
   public HttpClient.Response<TestCaseType> finishTest(TestCaseType test) {
     return this.basicClient.finishTest(test);
   }
@@ -77,6 +81,10 @@ public class DeltaClientImpl implements DeltaClient {
     this.extendedClient.finishTestRun(test_run_id, end_datetime, test_run_status);
   }
 
+  public void finishLaunch(Integer launch_id) {
+    this.extendedClient.finishLaunch(launch_id);
+  }
+
   public TestSuiteHistoryType registerTestSuiteHistory(
       String name, String test_type, String start_datetime, Integer test_run_id, String project) {
     return this.extendedClient.registerTestSuiteHistory(
@@ -90,7 +98,7 @@ public class DeltaClientImpl implements DeltaClient {
   }
 
   public TestCaseType registerTestCase(
-      String name, String datetime, Integer test_suite_id, Integer test_run_id, Integer test_suite_history_id) {
-    return this.extendedClient.registerTestCase(name, datetime, test_suite_id, test_run_id, test_suite_history_id);
+      String name, String datetime, String parameters, Integer test_suite_id,  Integer test_run_id, Integer test_suite_history_id) {
+    return this.extendedClient.registerTestCase(name, datetime, parameters, test_suite_id, test_run_id, test_suite_history_id);
   }
 }

--- a/src/main/java/com/deltareporter/client/impl/ExtendedClientImpl.java
+++ b/src/main/java/com/deltareporter/client/impl/ExtendedClientImpl.java
@@ -107,28 +107,40 @@ public class ExtendedClientImpl implements ExtendedClient {
     HttpClient.Response<TestRunType> response = this.client.finishTestRun(test_run);
   }
 
+  public void finishLaunch(Integer launch_id) {
+    LaunchType launch = new LaunchType(launch_id);
+    String launchDetails = "Launch ID: %s";
+    LOGGER.debug(
+        "Launch details:"
+            + String.format(
+                launchDetails, new Object[] {launch_id}));
+
+    HttpClient.Response<LaunchType> response = this.client.finishLaunch(launch);
+    LOGGER.debug("Launch finished! Response: " + response);
+  }
+
   public TestCaseType registerTestCase(
-      String name, String datetime, Integer test_suite_id, Integer test_run_id, Integer test_suite_history_id) {
-    TestCaseType testCase = new TestCaseType(name, datetime, test_suite_id, test_run_id, test_suite_history_id);
-    String testCaseDetails = "name: %s, datetime: %s, test_suite_id: %d, test_run_id: %d, test_suite_history_id: %d";
+      String name, String datetime, String parameters, Integer test_suite_id, Integer test_run_id, Integer test_suite_history_id) {
+    TestCaseType testCase = new TestCaseType(name, datetime, parameters, test_suite_id, test_run_id, test_suite_history_id);
+    String testCaseDetails = "name: %s, datetime: %s, parameters: %s, test_suite_id: %d, test_run_id: %d, test_suite_history_id: %d";
     LOGGER.debug(
         "Test Case details for registration:"
             + String.format(
-                testCaseDetails, new Object[] {name, datetime, test_suite_id, test_run_id, test_suite_history_id}));
+                testCaseDetails, new Object[] {name, datetime, parameters, test_suite_id, test_run_id, test_suite_history_id}));
     HttpClient.Response<TestCaseType> response = this.client.createTestCase(testCase);
     testCase = (TestCaseType) response.getObject();
     if (testCase == null) {
       throw new RuntimeException(
           "Unable to register test case '"
               + String.format(
-                  testCaseDetails, new Object[] {name, datetime, test_suite_id, test_run_id, test_suite_history_id})
+                  testCaseDetails, new Object[] {name, datetime, parameters, test_suite_id, test_run_id, test_suite_history_id})
               + "' for delta service: "
               + this.client.getServiceUrl());
     }
     LOGGER.debug(
         "Registered test case details:"
             + String.format(
-                testCaseDetails, new Object[] {name, datetime, test_suite_id, test_run_id, test_suite_history_id}));
+                testCaseDetails, new Object[] {name, datetime, parameters, test_suite_id, test_run_id, test_suite_history_id}));
 
     return testCase;
   }

--- a/src/main/java/com/deltareporter/config/DefaultConfigurator.java
+++ b/src/main/java/com/deltareporter/config/DefaultConfigurator.java
@@ -14,5 +14,9 @@ public class DefaultConfigurator implements IConfigurator {
     return adapter.getMethodAdapter().getMethodName();
   }
 
+  // public String getTestParameters(TestResultAdapter adapter) {
+  //   return adapter.getMethodAdapter().get;
+  // }
+
   public void clearArtifacts() {}
 }

--- a/src/main/java/com/deltareporter/listener/adapter/TestResultAdapter.java
+++ b/src/main/java/com/deltareporter/listener/adapter/TestResultAdapter.java
@@ -18,4 +18,6 @@ public interface TestResultAdapter {
   RuntimeException getSkipExceptionInstance(String paramString);
 
   MethodAdapter getMethodAdapter();
+
+  Object[] getParameters();
 }

--- a/src/main/java/com/deltareporter/listener/adapter/impl/TestResultAdapterImpl.java
+++ b/src/main/java/com/deltareporter/listener/adapter/impl/TestResultAdapterImpl.java
@@ -62,6 +62,11 @@ public class TestResultAdapterImpl implements TestResultAdapter {
     return new MethodAdapterImpl(this.testResult.getMethod());
   }
 
+  public Object[] getParameters() {
+    testResultNotNull();
+    return this.testResult.getParameters();
+  }
+
   private void testResultNotNull() {
     if (this.testResult == null)
       throw new RuntimeException("TestNG test result is required to apply its data");

--- a/src/main/java/com/deltareporter/listener/service/LaunchTypeService.java
+++ b/src/main/java/com/deltareporter/listener/service/LaunchTypeService.java
@@ -2,4 +2,6 @@ package com.deltareporter.listener.service;
 
 public interface LaunchTypeService {
   Integer register(String paramString1, String paramString2);
+
+  void finish(Integer paramInteger1);
 }

--- a/src/main/java/com/deltareporter/listener/service/TestCaseTypeService.java
+++ b/src/main/java/com/deltareporter/listener/service/TestCaseTypeService.java
@@ -4,7 +4,7 @@ import com.deltareporter.models.TestCaseType;
 
 public interface TestCaseTypeService {
   TestCaseType registerTestCase(
-      String paramString1, String paramString2, Integer paramInteger1, Integer paramInteger2, Integer paramInteger3);
+      String paramString1, String paramString2, String paramString3, Integer paramInteger1, Integer paramInteger2, Integer paramInteger3);
 
   TestCaseType finishTest(TestCaseType test);
 }

--- a/src/main/java/com/deltareporter/listener/service/impl/LaunchTypeServiceImpl.java
+++ b/src/main/java/com/deltareporter/listener/service/impl/LaunchTypeServiceImpl.java
@@ -13,4 +13,8 @@ public class LaunchTypeServiceImpl implements LaunchTypeService {
   public Integer register(String name, String project) {
     return this.deltaClient.registerLaunch(name, project);
   }
+
+  public void finish(Integer launch_id) {
+    this.deltaClient.finishLaunch(launch_id);
+  }
 }

--- a/src/main/java/com/deltareporter/listener/service/impl/TestCaseTypeServiceImpl.java
+++ b/src/main/java/com/deltareporter/listener/service/impl/TestCaseTypeServiceImpl.java
@@ -13,8 +13,8 @@ public class TestCaseTypeServiceImpl implements TestCaseTypeService {
   }
 
   public TestCaseType registerTestCase(
-      String name, String datetime, Integer test_suite_id, Integer test_run_id, Integer test_suite_history_id) {
-    return this.deltaClient.registerTestCase(name, datetime, test_suite_id, test_run_id, test_suite_history_id);
+      String name, String datetime, String parameters, Integer test_suite_id, Integer test_run_id, Integer test_suite_history_id) {
+    return this.deltaClient.registerTestCase(name, datetime, parameters, test_suite_id, test_run_id, test_suite_history_id);
   }
 
   public TestCaseType finishTest(TestCaseType test) {

--- a/src/main/java/com/deltareporter/models/LaunchType.java
+++ b/src/main/java/com/deltareporter/models/LaunchType.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.NotNull;
 public class LaunchType extends AbstractType {
   @NotNull private String name;
   @NotNull private String project;
+  private Integer launch_id;
 
   public void setName(String name) {
     this.name = name;
@@ -26,8 +27,16 @@ public class LaunchType extends AbstractType {
     return this.project;
   }
 
+  public Integer getLaunch_id() {
+    return this.launch_id;
+  }
+
   public LaunchType(String name, String project) {
     this.name = name;
     this.project = project;
+  }
+
+  public LaunchType(Integer launch_id) {
+    this.launch_id = launch_id;
   }
 }

--- a/src/main/java/com/deltareporter/models/TestCaseType.java
+++ b/src/main/java/com/deltareporter/models/TestCaseType.java
@@ -19,6 +19,7 @@ public class TestCaseType extends AbstractType {
   private String file;
   private String message;
   private String error_type;
+  private String parameters;
   private Integer retries;
 
   public void setTest_history_id(Integer test_history_id) {
@@ -59,6 +60,10 @@ public class TestCaseType extends AbstractType {
 
   public void setRetries(Integer retries) {
     this.retries = retries;
+  }
+
+  public void setParameters(String parameters) {
+    this.parameters = parameters;
   }
 
   public TestCaseType() {}
@@ -115,6 +120,10 @@ public class TestCaseType extends AbstractType {
     return this.error_type;
   }
 
+  public String getParameters() {
+    return this.parameters;
+  }
+
   public Integer getRetries() {
     return this.retries;
   }
@@ -123,9 +132,10 @@ public class TestCaseType extends AbstractType {
     return this.needRerun;
   }
 
-  public TestCaseType(String name, String datetime, Integer test_suite_id, Integer test_run_id, Integer test_suite_history_id) {
+  public TestCaseType(String name, String datetime, String parameters, Integer test_suite_id, Integer test_run_id, Integer test_suite_history_id) {
     this.name = name;
     this.start_datetime = datetime;
+    this.parameters = parameters;
     this.test_suite_id = test_suite_id;
     this.test_run_id = test_run_id;
     this.test_suite_history_id = test_suite_history_id;


### PR DESCRIPTION
- Parameters from a dataProvider are added to the title  (if params are detected), also this parameters are sent to Delta to be stored in the `parameters` column.
- Autogenerated launch name was updated from `Launch <timeStamp>` to `<testType> | <day> dd-MM-yyyy hh:mm:ss <AM|PM>`
- When the launch is generated by the client, it is finished by it when tests are finished

![Screenshot 2020-05-31 at 00 07 52](https://user-images.githubusercontent.com/14996980/83340698-30474e00-a2d3-11ea-855b-05090f8569a4.png)
